### PR TITLE
Feature/generator enhancement

### DIFF
--- a/bin/_generate.js
+++ b/bin/_generate.js
@@ -59,7 +59,7 @@ function testTemplatePath ({ type }) {
 }
 function testFullNamespace ({ pathPrefix, componentName }) {
   let splitted = pathPrefix.split('/')
-  return splitted.concat([componentName]).map(capitalize).join('::')
+  return splitted.filter(String).concat([componentName]).map(capitalize).join('::')
 }
 function capitalize (str) {
   let lead = str[0] ? str[0].toUpperCase() : '';

--- a/bin/action-test.template.js
+++ b/bin/action-test.template.js
@@ -1,11 +1,11 @@
-import * as actionCreators from 'actions/PATH_PREFIX/COMPONENT_NAME';
-import * as ActionType from 'actions/PATH_PREFIX/COMPONENT_NAME';
+import * as actionCreators from 'actions/PATH_PREFIX/COMPONENT_NAME'
+import * as ActionType from 'actions/PATH_PREFIX/COMPONENT_NAME'
 
-describe.only('Action::COMPONENT_FULL_NAMESPACE', function(){
-  describe('#THE_FUNC_NAME', function(){
-    it('returns an action of desired attrs', function(){
-      let action = actionCreators.THE_FUNC_NAME();
+describe.only('Action::COMPONENT_FULL_NAMESPACE', () => {
+  describe('#THE_FUNC_NAME', () => {
+    it('returns an action of desired attrs', () => {
+      let action = actionCreators.THE_FUNC_NAME()
       expect(action).to.deep.equal({ type: ActionType.MY_EVENT_TYPE })
-    });
-  });
-});
+    })
+  })
+})

--- a/bin/action.template.js
+++ b/bin/action.template.js
@@ -1,6 +1,6 @@
-import { CALL_API } from 'middlewares/api';
+import { CALL_API } from 'middlewares/api'
 
-export const MY_EVENT_TYPE = Symbol('MY_EVENT_TYPE');
+export const MY_EVENT_TYPE = Symbol('MY_EVENT_TYPE')
 export function THE_FUNC_NAME () {
   return {
     type: MY_EVENT_TYPE

--- a/bin/component-test.template.js
+++ b/bin/component-test.template.js
@@ -3,16 +3,16 @@ import { shallow } from 'enzyme'
 
 import COMPONENT_NAME from 'components/PATH_PREFIX/COMPONENT_NAME'
 
-describe.only('Component::COMPONENT_FULL_NAMESPACE', function(){
+describe.only('Component::COMPONENT_FULL_NAMESPACE', () => {
   let props
-  beforeEach(function(){
+  beforeEach(() => {
     props = {}
   })
   function renderDoc () {
     return shallow(<COMPONENT_NAME {...props} />)
   }
 
-  it('can be rendered', function(){
+  it('can be rendered', () => {
     let doc = renderDoc()
   })
 })

--- a/bin/container-test.template.js
+++ b/bin/container-test.template.js
@@ -3,18 +3,18 @@ import TestUtils from 'react-addons-test-utils'
 import { mount } from 'enzyme'
 import Container, { COMPONENT_NAME } from 'containers/PATH_PREFIX/COMPONENT_NAME'
 
-describe.only('Container::COMPONENT_FULL_NAMESPACE', function(){
+describe.only('Container::COMPONENT_FULL_NAMESPACE', () => {
   let props
 
   function renderDoc () {
     return mount(<COMPONENT_NAME {...props}/>)
   }
-  beforeEach(function(){
+  beforeEach(() => {
     props = {
     }
   })
 
-  it('can be rendered', function(){
+  it('can be rendered', () => {
     let doc = renderDoc()
   })
 

--- a/bin/reducer-test.template.js
+++ b/bin/reducer-test.template.js
@@ -1,13 +1,13 @@
-import reducer from 'reducers/PATH_PREFIX/COMPONENT_NAME';
-import * as ActionType from 'actions/PATH_PREFIX/COMPONENT_NAME';
+import reducer from 'reducers/PATH_PREFIX/COMPONENT_NAME'
+import * as ActionType from 'actions/PATH_PREFIX/COMPONENT_NAME'
 
-describe.only('Reducer::COMPONENT_FULL_NAMESPACE', function(){
-  describe('on ACTION_TYPE', function(){
-    it('should pass', function(){
-      let action = { type: 'case' };
-      let newState = reducer(undefined, action);
+describe.only('Reducer::COMPONENT_FULL_NAMESPACE', () => {
+  describe('on ACTION_TYPE', () => {
+    it('should pass', () => {
+      let action = { type: 'case' }
+      let newState = reducer(undefined, action)
 
-      expect(newState).to.equal('dummy');
-    });
-  });
-});
+      expect(newState).to.equal('dummy')
+    })
+  })
+})

--- a/bin/reducer.template.js
+++ b/bin/reducer.template.js
@@ -1,14 +1,14 @@
-import * as ActionType from 'actions/PATH_PREFIX/COMPONENT_NAME';
+import * as ActionType from 'actions/PATH_PREFIX/COMPONENT_NAME'
 
-let defaultState = {};
+let defaultState = {}
 
 export default function(state = defaultState, action) {
   switch(action.type) {
     case 'case':
-      return 'dummy';
-      break;
+      return 'dummy'
+      break
 
     default:
-      return state;
+      return state
   }
 }


### PR DESCRIPTION
1. To remove semicolons and use arrow function 
2. To fix redundant `::` generated by `testFullNamespace`

   - when run

   ```
   $ ./bin/generate container demo
   ```

   - Actual

   ```js
   // app/test/containers/demo.test.js
   describe.only('Container::::Demo', () => {
   ```

   - Expected

   ```js
   // app/test/containers/demo.test.js
   describe.only('Container::Demo', () => {
   ```