### PR TITLE
Bugfix/react invalid checksum

### DIFF
--- a/app/server/server.js
+++ b/app/server/server.js
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV === 'production') {
   server.use(Express.static(path.join(__dirname, '../..', 'public')))
 } else {
   server.use('/assets', Express.static(path.join(__dirname, '..', 'assets')))
-  server.use(Express.static(path.join(__dirname, '../..', 'dist')))
+  server.use(Express.static(path.join(__dirname, '../..', 'dist/css')))
 
   const webpackDevMiddleware = require('webpack-dev-middleware')
   const webpackHotMiddleware = require('webpack-hot-middleware')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ gulp.task('css', function() {
              cascade: false
            }))
            .pipe($.sourcemaps.write())
-           .pipe(gulp.dest('./dist'))
+           .pipe(gulp.dest('./dist/css'))
 })
 
 gulp.task('css:watch', ['css'], function() {


### PR DESCRIPTION
#### issue

After running `yarn build`, all built files are moved to `/dist`, which was used as a static path in the development mode. This could cause the inconsistency of rendering result between server and client.

#### solution

We only use `/dist/main.css` in development mode. Let's move it to `/dist/css` and make it as a static path.