### PR TITLE
Bugfix/rev-manifest and css path in production build

### DIFF
--- a/app/server/middlewares/universalRenderer.js
+++ b/app/server/middlewares/universalRenderer.js
@@ -17,7 +17,7 @@ if ( process.env.NODE_ENV === 'production' ) {
     `/${refManifest['vendor.js']}`,
     `/${refManifest['app.js']}`,
   ]
-  styleSrc = `/${refManifest['main.css']}`
+  styleSrc = `/${refManifest['css/main.css']}`
 } else {
   scriptSrcs = [
     '/vendor.js',

--- a/app/server/middlewares/universalRenderer.js
+++ b/app/server/middlewares/universalRenderer.js
@@ -12,7 +12,7 @@ let scriptSrcs
 
 let styleSrc
 if ( process.env.NODE_ENV === 'production' ) {
-  let refManifest = require('../../rev-manifest.json')
+  let refManifest = require('../../../rev-manifest.json')
   scriptSrcs = [
     `/${refManifest['vendor.js']}`,
     `/${refManifest['app.js']}`,


### PR DESCRIPTION
1. (production build) Fix path to `rev-manifest.json`

   ```
   dist/
   ...
   ├── rev-manifest.json
   ├── server-build
   │   ├── server
   │   │   ├── middlewares
   │   │   │   └── universalRenderer.js
   ...
   ```

2. (production build) Fix path to `main.css`. In https://github.com/mz026/universal-redux-template/pull/61, the destination of the `gulp css` task has moved from `/dist` to `/dist/css`